### PR TITLE
Update AppShell.xaml

### DIFF
--- a/Part 1- Displaying Data/MonkeyFinder/AppShell.xaml
+++ b/Part 1- Displaying Data/MonkeyFinder/AppShell.xaml
@@ -23,8 +23,7 @@
                 <Setter Property="Shell.TabBarUnselectedColor" Value="{AppThemeBinding Dark=#95FFFFFF, Light=#95000000}" />
                 <Setter Property="Shell.TabBarTitleColor" Value="{AppThemeBinding Dark={StaticResource LightBackground}, Light={StaticResource DarkBackground}}" />
             </Style>
-            <Style BasedOn="{StaticResource BaseStyle}" TargetType="TabBar" />
-            <Style BasedOn="{StaticResource BaseStyle}" TargetType="FlyoutItem" />
+            <Style BasedOn="{StaticResource BaseStyle}" TargetType="ShellItem" />
 
         </ResourceDictionary>
     </Shell.Resources>


### PR DESCRIPTION
So we need to fix this on the templates as well but 

```XAML
   <Style BasedOn="{StaticResource BaseStyle}" TargetType="TabBar" />
            <Style BasedOn="{StaticResource BaseStyle}" TargetType="FlyoutItem" />
```

won't really do anything because all you have here is `ShellContent`

What I'd really like to get to is for the this to work


```XAML
    <Shell.Resources>
        <ResourceDictionary>
            <Style TargetType="Shell">
                <Setter Property="Shell.BackgroundColor" Value="{AppThemeBinding Dark={StaticResource DarkBackground}, Light={StaticResource LightBackground}}" />
                <Setter Property="Shell.ForegroundColor" Value="{AppThemeBinding Dark={StaticResource LightBackground}, Light={StaticResource DarkBackground}}" />
                <Setter Property="Shell.TitleColor" Value="{AppThemeBinding Dark={StaticResource LightBackground}, Light={StaticResource DarkBackground}}" />
                <Setter Property="Shell.DisabledColor" Value="#B4FFFFFF" />
                <Setter Property="Shell.UnselectedColor" Value="{AppThemeBinding Dark=#95FFFFFF, Light=#95000000}" />
                <Setter Property="Shell.TabBarBackgroundColor" Value="{AppThemeBinding Dark={StaticResource DarkBackground}, Light={StaticResource LightBackground}}" />
                <Setter Property="Shell.TabBarForegroundColor" Value="{AppThemeBinding Dark={StaticResource LightBackground}, Light={StaticResource DarkBackground}}" />
                <Setter Property="Shell.TabBarUnselectedColor" Value="{AppThemeBinding Dark=#95FFFFFF, Light=#95000000}" />
                <Setter Property="Shell.TabBarTitleColor" Value="{AppThemeBinding Dark={StaticResource LightBackground}, Light={StaticResource DarkBackground}}" />
            </Style>
        </ResourceDictionary>
    </Shell.Resources>
```