### PR TITLE
Fixed RC1 code issues in ReadMe.

### DIFF
--- a/Part 4 - Platform Features/README.md
+++ b/Part 4 - Platform Features/README.md
@@ -18,21 +18,21 @@ We can add more functionality to this page using the GPS of the device since eac
     }
     ```
 
-1. Register the `Geolocation.Default` in our `MauiProgram.cs`.
+1. Register the `Geolocation.Current` in our `MauiProgram.cs`.
 
 
 1. While we are here let's add both `IGeolocation` and `IMap`, add the code:
 
     ```csharp
-    builder.Services.AddSingleton<IGeolocation>(Geolocation.Default);
-    builder.Services.AddSingleton<IMap>(Map.Default);
+    builder.Services.AddSingleton<IGeolocation>(Geolocation.Current);
+    builder.Services.AddSingleton<IMap>(Map.Current);
     ```
 
-1. In our `MonkeysViewModel.cs`, let's create another method called `GetClosestAsync`:
+1. In our `MonkeysViewModel.cs`, let's create another method called `GetClosestMonkey`:
 
     ```csharp
     [ICommand]
-    async Task GetClosestAsync()
+    async Task GetClosestMonkey()
     {
 
     }


### PR DESCRIPTION
Geolocation.Default and Map.Default didn't work, you'll get a build error because .Default isn't a known member. .Current will work.

Copying out "GetClosestAsync" and then replacing it right away with "GetClosestMonkey" seemed like it could be confusing. if someone just copied the stub of the method and then the method body from the "GetClosestMonkey" sample, they'd get a build error after adding the UI code, because a command with an incorrect name would be generate.