### PR TITLE
Fix up DetailsPage Visual

### DIFF
--- a/Part 4 - Platform Features/MonkeyFinder/View/DetailsPage.xaml
+++ b/Part 4 - Platform Features/MonkeyFinder/View/DetailsPage.xaml
@@ -33,7 +33,7 @@
                         WidthRequest="160"/>
                 </Frame>
             </Grid>
-            <VerticalStackLayout Margin="0,-50,0,0" Padding="10" Spacing="10">
+            <VerticalStackLayout Padding="10" Spacing="10">
                 <Label Style="{StaticResource MediumLabel}" Text="{Binding Monkey.Details}" />
                 <Label Style="{StaticResource MicroLabel}" Text="{Binding Monkey.Location, StringFormat='Location: {0}'}" />
                 <Label Style="{StaticResource MicroLabel}" Text="{Binding Monkey.Population, StringFormat='Population: {0}'}" />

--- a/Part 5 - CollectionView/MonkeyFinder/View/DetailsPage.xaml
+++ b/Part 5 - CollectionView/MonkeyFinder/View/DetailsPage.xaml
@@ -33,7 +33,7 @@
                         WidthRequest="160"/>
                 </Frame>
             </Grid>
-            <VerticalStackLayout Margin="0,-50,0,0" Padding="10" Spacing="10">
+            <VerticalStackLayout Padding="10" Spacing="10">
                 <Button Text="Show on Map" 
                         Command="{Binding OpenMapCommand}"
                         HorizontalOptions="Center" 

--- a/Part 6 - AppThemes/MonkeyFinder/View/DetailsPage.xaml
+++ b/Part 6 - AppThemes/MonkeyFinder/View/DetailsPage.xaml
@@ -33,7 +33,7 @@
                         WidthRequest="160"/>
                 </Frame>
             </Grid>
-            <VerticalStackLayout Margin="0,-50,0,0" Padding="10" Spacing="10">
+            <VerticalStackLayout Padding="10" Spacing="10">
                 <!-- Add this -->
                 <Button Text="Show on Map" 
                         Command="{Binding OpenMapCommand}"


### PR DESCRIPTION
The DetailsPage for Part 4 and up have a negative margin which is not in the instructions of the README for part 3 and also messes up the visuals at runtime