### PR TITLE
Added color to labels

### DIFF
--- a/Part 1 - Displaying Data/README.md
+++ b/Part 1 - Displaying Data/README.md
@@ -88,7 +88,7 @@ Add the following into the MainPage.xaml's `ContentPage`:
                     HeightRequest="100"
                     Source="{Binding Image}"
                     WidthRequest="100" />
-                <Label VerticalOptions="Center">
+                <Label VerticalOptions="Center" TextColor="Gray">
                     <Label.Text>
                         <MultiBinding StringFormat="{}{0} | {1}">
                             <Binding Path="Name" />
@@ -115,8 +115,8 @@ If we wanted to display the  two strings vertically on top of each other, we cou
         Source="{Binding Image}"
         WidthRequest="100" />
     <VerticalStackLayout VerticalOptions="Center">
-        <Label Text="{Binding Name}" FontSize="24"/>
-        <Label Text="{Binding Location}" FontSize="18"/>
+        <Label Text="{Binding Name}" FontSize="24" TextColor="Gray"/>
+        <Label Text="{Binding Location}" FontSize="18" TextColor="Gray"/>
     </VerticalStackLayout>
 </HorizontalStackLayout>
 ```

--- a/Part 4 - Platform Features/MonkeyFinder/View/MainPage.xaml
+++ b/Part 4 - Platform Features/MonkeyFinder/View/MainPage.xaml
@@ -34,7 +34,7 @@
                                     Padding="10">
                                     <Label Style="{StaticResource LargeLabel}" Text="{Binding Name}" />
                                     <Label Style="{StaticResource MediumLabel}" Text="{Binding Location}" />
-                                </StackLayout>
+                                </VerticalStackLayout>
                             </Grid>
                         </Frame>
                     </Grid>


### PR DESCRIPTION
Default Label's `TextColor` on Windows is almost invisible on the white background, unlike on Android, where the default `TextColor` for Label is Gray, so I added a `TextColor` property to the labels, with the value of the android label's default color, which is Gray.