### PR TITLE
Add Global.Json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+.idea/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.0",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
Putting the global.json in place makes sure folks who have preview versions of .NET installed can find the appropriate workloads. This keeps workloads in the `net6.0` family.