### PR TITLE
Update global.json to 6.0.300

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.0",
+    "version": "6.0.300",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
The only way to get the workloads that work with this solution is to have the `6.0.300` SDK installed. Anything below that will install outdated workloads that "sorta" work.