### PR TITLE
Update README.md

### DIFF
--- a/Part 2 - MVVM/README.md
+++ b/Part 2 - MVVM/README.md
@@ -272,11 +272,13 @@ We will use an `ObservableCollection<Monkey>` that will be cleared and then load
 
     ```csharp
     public ObservableCollection<Monkey> Monkeys { get; } = new();
-    MonkeyService monkeyService;
+    
+    MonkeyService monkeyService = new();
     public MonkeysViewModel(MonkeyService monkeyService)
     {
         Title = "Monkey Finder";
-        this.monkeyService = monkeyService;
+        this.monkeyService = monkeyService; // Compiler Warning CS1717 Assignment made to same variable; did you mean to assign something else?
+
     }
     ```
 


### PR DESCRIPTION
Assign a new MonkeyService instance to monkeyService at creation time.
Fixes the  Object reference not set to an instance of an object exception when: MonkeyService monkeyService;