### PR TITLE
Update GH Actions task versions

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -42,14 +42,14 @@ jobs:
         - Community Modules/XAML/Part 5 - Custom Types/Finish
         
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v2
       with:
         vs-prerelease: true
     


### PR DESCRIPTION
Builds gave some warnings about deprecations etc. 

This PR makes sure we're on the latest build tasks