### PR TITLE
Fix Directory.Build.props and Directory.Build.targets links in solution items

### DIFF
--- a/Community Modules/XAML/Part 1 - Fundamentals/Finish/MonkeyFinder.sln
+++ b/Community Modules/XAML/Part 1 - Fundamentals/Finish/MonkeyFinder.sln
@@ -7,8 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyFinder", "MonkeyFinde
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{393B8F30-F402-46A9-B209-8C71897A3416}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.build.props = ..\Directory.build.props
-		..\Directory.build.targets = ..\Directory.build.targets
+		..\..\..\..\Directory.Build.props = ..\..\..\..\Directory.Build.props
+		..\..\..\..\Directory.Build.targets = ..\..\..\..\Directory.Build.targets
 	EndProjectSection
 EndProject
 Global

--- a/Community Modules/XAML/Part 2 - Responsibility/Finish/MonkeyFinder.sln
+++ b/Community Modules/XAML/Part 2 - Responsibility/Finish/MonkeyFinder.sln
@@ -7,8 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyFinder", "MonkeyFinde
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{393B8F30-F402-46A9-B209-8C71897A3416}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.build.props = ..\Directory.build.props
-		..\Directory.build.targets = ..\Directory.build.targets
+		..\..\..\..\Directory.Build.props = ..\..\..\..\Directory.Build.props
+		..\..\..\..\Directory.Build.targets = ..\..\..\..\Directory.Build.targets
 	EndProjectSection
 EndProject
 Global

--- a/Community Modules/XAML/Part 3 - Magic Values/Finish/MonkeyFinder.sln
+++ b/Community Modules/XAML/Part 3 - Magic Values/Finish/MonkeyFinder.sln
@@ -7,8 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyFinder", "MonkeyFinde
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{393B8F30-F402-46A9-B209-8C71897A3416}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.build.props = ..\Directory.build.props
-		..\Directory.build.targets = ..\Directory.build.targets
+		..\..\..\..\Directory.Build.props = ..\..\..\..\Directory.Build.props
+		..\..\..\..\Directory.Build.targets = ..\..\..\..\Directory.Build.targets
 	EndProjectSection
 EndProject
 Global

--- a/Community Modules/XAML/Part 4 - Naming/Finish/MonkeyFinder.sln
+++ b/Community Modules/XAML/Part 4 - Naming/Finish/MonkeyFinder.sln
@@ -7,8 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyFinder", "MonkeyFinde
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{393B8F30-F402-46A9-B209-8C71897A3416}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.build.props = ..\Directory.build.props
-		..\Directory.build.targets = ..\Directory.build.targets
+		..\..\..\..\Directory.Build.props = ..\..\..\..\Directory.Build.props
+		..\..\..\..\Directory.Build.targets = ..\..\..\..\Directory.Build.targets
 	EndProjectSection
 EndProject
 Global

--- a/Community Modules/XAML/Part 5 - Custom Types/Finish/MonkeyFinder.sln
+++ b/Community Modules/XAML/Part 5 - Custom Types/Finish/MonkeyFinder.sln
@@ -7,8 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyFinder", "MonkeyFinde
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{393B8F30-F402-46A9-B209-8C71897A3416}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.build.props = ..\Directory.build.props
-		..\Directory.build.targets = ..\Directory.build.targets
+		..\..\..\..\Directory.Build.props = ..\..\..\..\Directory.Build.props
+		..\..\..\..\Directory.Build.targets = ..\..\..\..\Directory.Build.targets
 	EndProjectSection
 EndProject
 Global

--- a/Finish/MonkeyFinder.sln
+++ b/Finish/MonkeyFinder.sln
@@ -7,8 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyFinder", "MonkeyFinde
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{393B8F30-F402-46A9-B209-8C71897A3416}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.build.props = ..\Directory.build.props
-		..\Directory.build.targets = ..\Directory.build.targets
+		..\Directory.Build.props = ..\Directory.Build.props
+		..\Directory.Build.targets = ..\Directory.Build.targets
 	EndProjectSection
 EndProject
 Global

--- a/Part 1 - Displaying Data/MonkeyFinder.sln
+++ b/Part 1 - Displaying Data/MonkeyFinder.sln
@@ -7,8 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyFinder", "MonkeyFinde
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{393B8F30-F402-46A9-B209-8C71897A3416}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.build.props = ..\Directory.build.props
-		..\Directory.build.targets = ..\Directory.build.targets
+		..\Directory.Build.props = ..\Directory.Build.props
+		..\Directory.Build.targets = ..\Directory.Build.targets
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Part 2 - MVVM/MonkeyFinder.sln
+++ b/Part 2 - MVVM/MonkeyFinder.sln
@@ -7,8 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyFinder", "MonkeyFinde
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{393B8F30-F402-46A9-B209-8C71897A3416}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.build.props = ..\Directory.build.props
-		..\Directory.build.targets = ..\Directory.build.targets
+		..\Directory.Build.props = ..\Directory.Build.props
+		..\Directory.Build.targets = ..\Directory.Build.targets
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Part 3 - Navigation/MonkeyFinder.sln
+++ b/Part 3 - Navigation/MonkeyFinder.sln
@@ -7,8 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyFinder", "MonkeyFinde
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{393B8F30-F402-46A9-B209-8C71897A3416}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.build.props = ..\Directory.build.props
-		..\Directory.build.targets = ..\Directory.build.targets
+		..\Directory.Build.props = ..\Directory.Build.props
+		..\Directory.Build.targets = ..\Directory.Build.targets
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Part 4 - Platform Features/MonkeyFinder.sln
+++ b/Part 4 - Platform Features/MonkeyFinder.sln
@@ -7,8 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyFinder", "MonkeyFinde
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{393B8F30-F402-46A9-B209-8C71897A3416}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.build.props = ..\Directory.build.props
-		..\Directory.build.targets = ..\Directory.build.targets
+		..\Directory.Build.props = ..\Directory.Build.props
+		..\Directory.Build.targets = ..\Directory.Build.targets
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Part 5 - CollectionView/MonkeyFinder.sln
+++ b/Part 5 - CollectionView/MonkeyFinder.sln
@@ -7,8 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyFinder", "MonkeyFinde
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{393B8F30-F402-46A9-B209-8C71897A3416}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.build.props = ..\Directory.build.props
-		..\Directory.build.targets = ..\Directory.build.targets
+		..\Directory.Build.props = ..\Directory.Build.props
+		..\Directory.Build.targets = ..\Directory.Build.targets
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Part 6 - AppThemes/MonkeyFinder.sln
+++ b/Part 6 - AppThemes/MonkeyFinder.sln
@@ -7,8 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonkeyFinder", "MonkeyFinde
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{393B8F30-F402-46A9-B209-8C71897A3416}"
 	ProjectSection(SolutionItems) = preProject
-		..\Directory.build.props = ..\Directory.build.props
-		..\Directory.build.targets = ..\Directory.build.targets
+		..\Directory.Build.props = ..\Directory.Build.props
+		..\Directory.Build.targets = ..\Directory.Build.targets
 		README.md = README.md
 	EndProjectSection
 EndProject


### PR DESCRIPTION
Turned out I haven't fixed all the issues with `Directory.Build.props` and `Directory.Build.targets` in my [last PR](https://github.com/dotnet-presentations/dotnet-maui-workshop/pull/126).

Changes:
1. Renamed `Directory.build.props` to `Directory.Build.props` in `.sln` files
2. Renamed `Directory.build.targets` to `Directory.Build.targets`  in `.sln` files
3. Fixed relative paths to `Directory.build`  files in `.sln` files within `Community Modules` dir